### PR TITLE
🟢 Low: Add view controller shorthand [Tiny]

### DIFF
--- a/Sources/HostedView+UIKit.swift
+++ b/Sources/HostedView+UIKit.swift
@@ -10,6 +10,11 @@ import SwiftUI
 
 public extension HostedView {
 
+    /// Shorthand to get the `viewController` of the `hostingController`
+    var viewController: UIViewController? {
+        hostingController?.viewController
+    }
+
     /// Present the given `viewController`
     /// - Parameters:
     ///   - viewController: `UIViewController` to present

--- a/Sources/HostedView+UIKit.swift
+++ b/Sources/HostedView+UIKit.swift
@@ -23,16 +23,13 @@ public extension HostedView {
         _ viewController: UIViewController,
         animated: Bool = true
     ) {
-        hostingController?.viewController?.present(
-            viewController,
-            animated: animated
-        )
+        self.viewController?.present(viewController, animated: animated)
     }
 
     /// Dismiss the view controller
     /// - Parameter animated: `Bool` animated, defaults to `true`
     func dismiss(animated: Bool = true) {
-        hostingController?.viewController?.dismiss(animated: animated)
+        viewController?.dismiss(animated: animated)
     }
 
     /// Push the given SwiftUI `contentView` on the navigation stack


### PR DESCRIPTION
Add computed property to `HostedView` to get the `viewController` from the `hostingController`